### PR TITLE
Added easier support for PKCS #12 keystores

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Oracle Weblogic Server implements out-of-the-box the [web browser SSO profile of
 1. How to get the user information from the IdP SAMLResponse: [WlsAttributeNameMapper](https://github.com/cerndb/wls-cern-sso/tree/master/WlsAttributeNameMapper)
 2. The [Single Log Out profile](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0-cd-02.html):[saml2slo](https://github.com/cerndb/wls-cern-sso/tree/master/saml2slo)
 
+## Source code and instructions
+
+The project's source code and building instructions are available in the [saml2slo](/saml2slo) folder.
+
 ## Authors
 
 These libraries have been written by [Luis Rodríguez Fernandez](http://profiles.web.cern.ch/720335).

--- a/saml2slo/README.md
+++ b/saml2slo/README.md
@@ -21,19 +21,22 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.65-b04, mixed mode)
 
 You will need to add the next libraries to your **classpath**:
 
-* [$WL_HOME/server/lib/api.jar](http://docs.oracle.com/middleware/1212/wls/NOTES/index.html#CJAEGAAB) 
-* **$WL_HOME/server/lib/api.jar**: it loads the **Servlet API** among many others (take a look at its *MANIFEST.MF*).
-* **$WL_HOME/modules/com.bea.core.utils_2.3.0.0.jar**: it contains utility classes like *weblogic.utils.encoders.BASE64Encoder*
+* [${WL_HOME}/server/lib/wls-api.jar](https://docs.oracle.com/middleware/1212/wls/WLPRG/overview.htm#WLPRG838) &ast;
+* **${WL_HOME}/server/lib/api.jar &ast;**: it loads the **Servlet API** among many others (take a look at its *MANIFEST.MF*).
+* **${WL_HOME}/modules/com.bea.core.utils_2.3.0.0.jar &ast;**: it contains utility classes like *weblogic.utils.encoders.BASE64Encoder*
 * **saml2slo/WEB-INF/lib/bcprov-jdk15-1.46.jar**: this library stores the *org.bouncycastle.util.encoders.Hex* class used for the hex encoded of the *ID* element of the *samlp:LogoutRequest*. See more at [The Legion of the Bouncy Castle](https://www.bouncycastle.org/java.html)
 * **saml2slo/WEB-INF/lib/commons-codec-1.3.jar**: I use the *org.apache.commons.codec.binary.Base64* from this .jar for verifying the URL signature of the logout request and for decoding/encoding and inflating/deflating the responses and requests.
 
-The library is packaged as a **.war**. You can use the **war** [ant target](https://ant.apache.org/manual/targets.html) of the [build.xml](https://github.com/cerndb/wls-cern-sso/blob/master/WlsAttributeNameMapper/build.xml). Remember to update the **classpath** [fileset](https://ant.apache.org/manual/Types/fileset.html) of the compile target with above jars.
+
+&ast; **${WL_HOME}** is the installation path of WebLogic Server. It has been tested to work with WebLogic Server `12.1.3.0`. In order to build the project using a different installation of WebLogic, the required libraries might be different.
+
+The library is packaged as a **.war**. You can use the **war** [ant target](https://ant.apache.org/manual/targets.html) of the [build.xml](https://github.com/cerndb/wls-cern-sso/blob/master/WlsAttributeNameMapper/build.xml), replacing `PATH_TO_WLS_INSTALLATION` with the path to your WebLogic installation (typically, it will be the folder `wlserver`, inside of the folder where you installed WebLogic) . Remember to update the **classpath** [fileset](https://ant.apache.org/manual/Types/fileset.html) of the compile target with above jars.
 
 If you want to test the **JMX** connection with your Oracle Weblogic Server, you can run the **saml2slo/test/JMXclient** class. It requires these other libraries in your **classpath**:
 
-* **$WL_HOME/modulescom.bea.core.weblogic.security.identity_3.1.0.0.jar**
-* **$WL_HOME/server/lib/weblogic.jar**
-* **$WL_HOME/server/lib/wljmxclient.jar**
+* **${WL_HOME}/modulescom.bea.core.weblogic.security.identity_3.1.0.0.jar**
+* **${WL_HOME}/server/lib/weblogic.jar**
+* **${WL_HOME}/server/lib/wljmxclient.jar**
 
 ## Installation and configuration
 

--- a/saml2slo/WebContent/WEB-INF/web.xml
+++ b/saml2slo/WebContent/WEB-INF/web.xml
@@ -30,18 +30,6 @@
 	</context-param>
 
 	<context-param>
-		<description>Keystore type</description>
-		<param-name>keystoreType</param-name>
-		<param-value>JKS</param-value>
-	</context-param>
-
-	<context-param>
-		<description>Keystore provider</description>
-		<param-name>keystoreProvider</param-name>
-		<param-value>SUN</param-value>
-	</context-param>
-
-	<context-param>
 		<description>Keystore password key</description>
 		<param-name>keystorePasswordKey</param-name>
 		<param-value>password_keystore_weblogic_jks</param-value>

--- a/saml2slo/build.xml
+++ b/saml2slo/build.xml
@@ -9,6 +9,8 @@ or submit itself to any jurisdiction.
 -->
 <project name="saml2slo" default="war" basedir=".">
 
+	<property name="WLS_HOME" value="PATH_TO_WLS_INSTALLATION"/>
+	
 	<!-- Creates the bin (.classes) and build (.jar) directories -->
 	<target name="init" depends="clean">
 		<mkdir dir="bin" />
@@ -28,11 +30,12 @@ or submit itself to any jurisdiction.
 		<javac srcdir="src" destdir="bin" debug="on" debuglevel="lines,vars,source">
 			<classpath>
 				<path>
-					<fileset dir="/home/lurodrig/development/servers/wls12130/wlserver/server/lib/">
+					<fileset dir="${WLS_HOME}/server/lib/">
 						<include name="wls-api.jar" />
 						<include name="api.jar" />
+						<include name="wlclient.jar" />
 					</fileset>
-					<fileset dir="/home/lurodrig/development/servers/wls12130/wlserver/modules/">
+					<fileset dir="${WLS_HOME}/modules/">
 						<include name="com.bea.core.utils_2.3.0.0.jar" />
 					</fileset>
 					<fileset dir="WebContent/WEB-INF/lib">

--- a/saml2slo/src/ch/cern/security/saml2/listener/Saml2sloContextListener.java
+++ b/saml2slo/src/ch/cern/security/saml2/listener/Saml2sloContextListener.java
@@ -36,11 +36,11 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
-import weblogic.logging.NonCatalogLogger;
 import ch.cern.security.saml2.jmx.JmxConstants;
 import ch.cern.security.saml2.jmx.JmxUtils;
 import ch.cern.security.saml2.utils.ScriptUtils;
 import conf.Constants;
+import weblogic.logging.NonCatalogLogger;
 
 public class Saml2sloContextListener implements ServletContextListener {
 
@@ -50,15 +50,13 @@ public class Saml2sloContextListener implements ServletContextListener {
 	 * :%2F%2Fdownload.oracle.com%2Fdocs%2Fcd%2FE24329_01%2Fweb.1211%2Fe24419%2F
 	 * writing.htm%23LOGSV159
 	 */
-	private NonCatalogLogger nc = new NonCatalogLogger(this.getClass()
-			.getName());
+	private NonCatalogLogger nc = new NonCatalogLogger(this.getClass().getName());
 
 	/**
 	 * 
 	 */
-	private static final String KEYSTORE_TYPE = "keystoreType";
-	private static final String KEYSTORE_PROVIDER = "keystoreProvider";
 	private static final String CUSTOM_IDENTITY_KEYSTORE_FILE_NAME = "CustomIdentityKeyStoreFileName";
+	private static final String CUSTOM_IDENTITY_KEYSTORE_TYPE = "CustomIdentityKeyStoreType";
 	private static final String KEYSTORE_PASSWORD = "keystorePasswordKey";
 	private static final String PRIVATE_KEY_PASSWORD = "privateKeyPasswordKey";
 	private static final String GET_PASSWD_SCRIPT = "getPasswdScript";
@@ -78,8 +76,7 @@ public class Saml2sloContextListener implements ServletContextListener {
 		try {
 
 			// Get the ServletContext
-			ServletContext servletContext = servletContextEvent
-					.getServletContext();
+			ServletContext servletContext = servletContextEvent.getServletContext();
 
 			/*
 			 * If ServletContext is null the deployment must be stopped TODO: we
@@ -87,8 +84,7 @@ public class Saml2sloContextListener implements ServletContextListener {
 			 * failed
 			 */
 			if (servletContext == null) {
-				throw new RuntimeException(
-						Constants.SERVLET_CONTEXT_NULL_EXCEPTION);
+				throw new RuntimeException(Constants.SERVLET_CONTEXT_NULL_EXCEPTION);
 			}
 
 			// Get the SP SSO private key
@@ -96,8 +92,7 @@ public class Saml2sloContextListener implements ServletContextListener {
 			// Store the SP SSO private key in the servlet context
 			if (privateKey != null) {
 				nc.notice("SP private key got");
-				servletContextEvent.getServletContext().setAttribute(
-						Constants.SP_PRIVATE_KEY, privateKey);
+				servletContextEvent.getServletContext().setAttribute(Constants.SP_PRIVATE_KEY, privateKey);
 			} else {
 				throw new RuntimeException(Constants.SP_PRIVATE_KEY_EXCEPTION);
 			}
@@ -106,8 +101,7 @@ public class Saml2sloContextListener implements ServletContextListener {
 			PublicKey publicKey = getIdpPublicKey(servletContext);
 			if (publicKey != null) {
 				nc.notice("IdP public key got");
-				servletContextEvent.getServletContext().setAttribute(
-						Constants.IDP_PUBLIC_KEY, publicKey);
+				servletContextEvent.getServletContext().setAttribute(Constants.IDP_PUBLIC_KEY, publicKey);
 			} else {
 				throw new RuntimeException(Constants.IDP_PUBLIC_KEY_EXCEPTION);
 			}
@@ -117,32 +111,27 @@ public class Saml2sloContextListener implements ServletContextListener {
 			// Store the sigAlg in the servlet context
 			if (sigAlg != null) {
 				nc.notice(sigAlg);
-				servletContextEvent.getServletContext().setAttribute(
-						Constants.SIG_ALG, sigAlg);
+				servletContextEvent.getServletContext().setAttribute(Constants.SIG_ALG, sigAlg);
 			} else {
 				throw new RuntimeException(Constants.SIG_ALG_EXCEPTION);
 			}
 
 			// Get the algorithm entityID
-			String algorithm = servletContext
-					.getInitParameter(Constants.ALGORITHM);
+			String algorithm = servletContext.getInitParameter(Constants.ALGORITHM);
 			// Store the algorithm in the servlet context
 			if (algorithm != null) {
 				nc.notice(algorithm);
-				servletContextEvent.getServletContext().setAttribute(
-						Constants.ALGORITHM, algorithm);
+				servletContextEvent.getServletContext().setAttribute(Constants.ALGORITHM, algorithm);
 			} else {
 				throw new RuntimeException(Constants.ALGORITHM_EXCEPTION);
 			}
 
 			// Get the idpEndpoint
-			String idpEndpoint = servletContext
-					.getInitParameter(Constants.IDP_ENDPOINT);
+			String idpEndpoint = servletContext.getInitParameter(Constants.IDP_ENDPOINT);
 			// Store the idpEndpoint in the servlet context
 			if (idpEndpoint != null) {
 				nc.notice(idpEndpoint);
-				servletContextEvent.getServletContext().setAttribute(
-						Constants.IDP_ENDPOINT, idpEndpoint);
+				servletContextEvent.getServletContext().setAttribute(Constants.IDP_ENDPOINT, idpEndpoint);
 			} else {
 				throw new RuntimeException(Constants.IDP_ENDPOINT_EXCEPTION);
 			}
@@ -152,8 +141,7 @@ public class Saml2sloContextListener implements ServletContextListener {
 			// Store the entityID in the servlet context
 			if (entityID != null) {
 				nc.notice(entityID);
-				servletContextEvent.getServletContext().setAttribute(
-						Constants.ENTITY_ID, entityID);
+				servletContextEvent.getServletContext().setAttribute(Constants.ENTITY_ID, entityID);
 			} else {
 				throw new RuntimeException(Constants.ENTITY_ID_EXCEPTION);
 			}
@@ -165,95 +153,91 @@ public class Saml2sloContextListener implements ServletContextListener {
 	}
 
 	private PublicKey getIdpPublicKey(ServletContext servletContext)
-			throws NamingException, MalformedObjectNameException,
-			AttributeNotFoundException, InstanceNotFoundException,
-			MBeanException, ReflectionException, NoSuchAlgorithmException,
-			InvalidKeySpecException, NoSuchProviderException,
-			CertificateException, IOException {
+			throws NamingException, MalformedObjectNameException, AttributeNotFoundException, InstanceNotFoundException,
+			MBeanException, ReflectionException, NoSuchAlgorithmException, InvalidKeySpecException,
+			NoSuchProviderException, CertificateException, IOException {
 		/*
 		 * Retrieve the public key using the Weblogic Server configuration
 		 * (through JMX) and store it in the ServletContext
 		 */
 
 		// Get the Authenticator Provider Name
-		String authenticationProviderName = servletContext
-				.getInitParameter(AUTHENTICATOR_PROVIDER_NAME);
+		String authenticationProviderName = servletContext.getInitParameter(AUTHENTICATOR_PROVIDER_NAME);
 
 		// Get the Web SSO IdP partner name
-		String webSSOpartnerName = servletContext
-				.getInitParameter(WEB_SSO_PARTNER_NAME);
+		String webSSOpartnerName = servletContext.getInitParameter(WEB_SSO_PARTNER_NAME);
 
-		String credentials = ScriptUtils.getValueFromScript(
-				servletContext.getInitParameter(GET_PASSWD_SCRIPT),
+		String credentials = ScriptUtils.getValueFromScript(servletContext.getInitParameter(GET_PASSWD_SCRIPT),
 				PASSWORD_WEBLOGIC + JmxUtils.getDomainValue(JmxConstants.NAME));
 
 		// Get the encoded byte[] of the key
-		byte[] encodedBytes = (byte[]) JmxUtils.getCertificate(
-				authenticationProviderName, webSSOpartnerName,
+		byte[] encodedBytes = (byte[]) JmxUtils.getCertificate(authenticationProviderName, webSSOpartnerName,
 				JmxConstants.SECURITY_PRINCIPAL, credentials);
 
 		// Create the certificate
-		CertificateFactory certificateFactory = CertificateFactory
-				.getInstance("X509");
-		Certificate certificate = certificateFactory
-				.generateCertificate(new ByteArrayInputStream(encodedBytes));
-		
+		CertificateFactory certificateFactory = CertificateFactory.getInstance("X509");
+		Certificate certificate = certificateFactory.generateCertificate(new ByteArrayInputStream(encodedBytes));
+
 		// Get the public key
 		return certificate.getPublicKey();
 	}
 
-	private String getEntityID() throws NamingException,
-			MalformedObjectNameException, AttributeNotFoundException,
+	private String getEntityID() throws NamingException, MalformedObjectNameException, AttributeNotFoundException,
 			InstanceNotFoundException, MBeanException, ReflectionException {
 		// Retrieve the entityID attribute (The string that uniquely
 		// identifies the local site) from the Federation Services
 		// configuration of the server
-		String entityID = (String) JmxUtils.getValue(
-				JmxConstants.RUNTIME_SERVICE,
-				JmxConstants.SINGLE_SIGN_ON_SERVICES, Constants.ENTITY_ID,
-				JmxConstants.RUNTIME_SERVICE_MBEAN);
+		String entityID = (String) JmxUtils.getValue(JmxConstants.RUNTIME_SERVICE, JmxConstants.SINGLE_SIGN_ON_SERVICES,
+				Constants.ENTITY_ID, JmxConstants.RUNTIME_SERVICE_MBEAN);
 		return entityID;
 	}
 
 	private PrivateKey getPrivateKey(ServletContext servletContext)
-			throws IOException, KeyStoreException, NoSuchProviderException,
-			FileNotFoundException, NamingException,
-			MalformedObjectNameException, AttributeNotFoundException,
-			InstanceNotFoundException, MBeanException, ReflectionException,
-			NoSuchAlgorithmException, CertificateException,
-			UnrecoverableKeyException {
+			throws IOException, KeyStoreException, NoSuchProviderException, FileNotFoundException, NamingException,
+			MalformedObjectNameException, AttributeNotFoundException, InstanceNotFoundException, MBeanException,
+			ReflectionException, NoSuchAlgorithmException, CertificateException, UnrecoverableKeyException {
 		/*
 		 * Retrieve the private key using the Weblogic Server configuration
 		 * (through JMX) and store it in the ServletContext
 		 */
 
 		// Get keystore password (jks file)
-		String keyStorePassword = ScriptUtils.getValueFromScript(
-				servletContext.getInitParameter(GET_PASSWD_SCRIPT),
+		String keyStorePassword = ScriptUtils.getValueFromScript(servletContext.getInitParameter(GET_PASSWD_SCRIPT),
 				servletContext.getInitParameter(KEYSTORE_PASSWORD));
 
-		// Get key password (alias sso-...)
-		String privateKeyPassword = ScriptUtils.getValueFromScript(
-				servletContext.getInitParameter(GET_PASSWD_SCRIPT),
-				servletContext.getInitParameter(PRIVATE_KEY_PASSWORD));
+		// Get keystore type ('jks' or 'pkcs12')
+		String keyStoreType = JmxUtils.getValue(CUSTOM_IDENTITY_KEYSTORE_TYPE);
 
 		// Instantiate a keystore object
-		KeyStore keyStore = KeyStore.getInstance(
-				servletContext.getInitParameter(KEYSTORE_TYPE),
-				servletContext.getInitParameter(KEYSTORE_PROVIDER));
+		KeyStore keyStore = KeyStore.getInstance(keyStoreType);
 
 		// Load the keystore (open file and load bytes into keystore object)
-		FileInputStream stream = new FileInputStream(
-				JmxUtils.getValue(CUSTOM_IDENTITY_KEYSTORE_FILE_NAME));
+		FileInputStream stream = new FileInputStream(JmxUtils.getValue(CUSTOM_IDENTITY_KEYSTORE_FILE_NAME));
 		keyStore.load(stream, keyStorePassword.toCharArray());
 
+		// Password for the private key:
+		// - equal to the keystore's password for PKCS #12 keystores
+		// - 'GET_PASSWD' value for JKS keystores
+		char[] privateKeyPassword = null;
+
+		if (keyStore.getType().equals("PKCS12")) {
+			// In PKCS #12 keystores, the same password must be used for the
+			// keystore and the private keys
+			privateKeyPassword = keyStorePassword.toCharArray();
+		} else {
+			// JKS keystores encrypt the private keys with arbitrary passwords,
+			// so it's necessary to get it and use it
+			privateKeyPassword = ScriptUtils.getValueFromScript(servletContext.getInitParameter(GET_PASSWD_SCRIPT),
+					servletContext.getInitParameter(PRIVATE_KEY_PASSWORD)).toCharArray();
+		}
+
+		// Get the private key's alias
+		String privateKeyAlias = (String) JmxUtils.getValue(JmxConstants.RUNTIME_SERVICE,
+				JmxConstants.SINGLE_SIGN_ON_SERVICES, Constants.SSO_SIGNING_KEY_ALIAS,
+				JmxConstants.RUNTIME_SERVICE_MBEAN);
+
 		// Get the key (through its alias) from the keystore
-		PrivateKey privateKey = (PrivateKey) keyStore.getKey((String) JmxUtils
-				.getValue(JmxConstants.RUNTIME_SERVICE,
-						JmxConstants.SINGLE_SIGN_ON_SERVICES,
-						Constants.SSO_SIGNING_KEY_ALIAS,
-						JmxConstants.RUNTIME_SERVICE_MBEAN), privateKeyPassword
-				.toCharArray());
+		PrivateKey privateKey = (PrivateKey) keyStore.getKey(privateKeyAlias, privateKeyPassword);
 
 		return privateKey;
 	}


### PR DESCRIPTION
- Added a link in the main README to the `saml2slo` folder
- Removed the `Keystore type` and `Keystore provider` from the `web.xml` file constants, because now this information is read from the WLS MBeans
- Added a check for the keystore type, and if it's a `PKCS12` keystore, then the code will assume that the password for the private keys will be a;ways the same as the keystore's password, so it doesn't have to read it from the passwords file
- Fix the name and link to the required `wls-api.jar` library
- Added a variable for WebLogic installation path in the `build.xml` file, it was currently hardcoded